### PR TITLE
fix: resolve OtherTargetBound deadlock when stale RS IP is reused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# git worktrees
+.worktrees/

--- a/internal/clbbinding/clbbinding.go
+++ b/internal/clbbinding/clbbinding.go
@@ -14,6 +14,9 @@ type CLBBinding interface {
 	GetStatus() *networkingv1alpha1.CLBBindingStatus
 	GetAssociatedObject(context.Context, client.Client) (Backend, error)
 	GetAssociatedObjectByIP(context.Context, client.Client, string) (Backend, error)
+	// IsListenerOwnedByBackend 判断 other 对象是否通过自己的 CLBBinding 合法占用了指定的 listenerId。
+	// 用于区分"IP 被无关对象复用"（历史残留，可安全清理）与"另一 binding 合法占用同一监听器"（真冲突，需保护）。
+	IsListenerOwnedByBackend(ctx context.Context, c client.Client, other Backend, listenerId string) (bool, error)
 	GetObject() client.Object
 	GetType() string
 	FetchObject(context.Context, client.Client) (client.Object, error)

--- a/internal/clbbinding/clbnodebinding.go
+++ b/internal/clbbinding/clbnodebinding.go
@@ -7,6 +7,7 @@ import (
 	networkingv1alpha1 "github.com/tkestack/tke-extend-network-controller/api/v1alpha1"
 	"github.com/tkestack/tke-extend-network-controller/pkg/eventsource"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -100,4 +101,22 @@ func (b *CLBNodeBinding) GetAssociatedObjectByIP(ctx context.Context, apiClient 
 		return nodeBackend{&nodeList.Items[0]}, nil
 	}
 	return nil, nil
+}
+
+func (b *CLBNodeBinding) IsListenerOwnedByBackend(ctx context.Context, c client.Client, other Backend, listenerId string) (bool, error) {
+	obj := other.GetObject()
+	cnb := &networkingv1alpha1.CLBNodeBinding{}
+	err := c.Get(ctx, client.ObjectKey{Name: obj.GetName()}, cnb)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.WithStack(err)
+	}
+	for _, pb := range cnb.Status.PortBindings {
+		if pb.ListenerId == listenerId {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/clbbinding/clbpodbinding.go
+++ b/internal/clbbinding/clbpodbinding.go
@@ -8,6 +8,7 @@ import (
 	networkingv1alpha1 "github.com/tkestack/tke-extend-network-controller/api/v1alpha1"
 	"github.com/tkestack/tke-extend-network-controller/pkg/eventsource"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -112,4 +113,22 @@ func (b *CLBPodBinding) GetAssociatedObject(ctx context.Context, apiClient clien
 		return nil, errors.WithStack(err)
 	}
 	return podBackend{pod, apiClient}, nil
+}
+
+func (b *CLBPodBinding) IsListenerOwnedByBackend(ctx context.Context, c client.Client, other Backend, listenerId string) (bool, error) {
+	obj := other.GetObject()
+	cpb := &networkingv1alpha1.CLBPodBinding{}
+	err := c.Get(ctx, client.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}, cpb)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil // 该 Pod 没有 CLBPodBinding（如 fluent-bit）→ 非合法占用
+		}
+		return false, errors.WithStack(err)
+	}
+	for _, pb := range cpb.Status.PortBindings {
+		if pb.ListenerId == listenerId {
+			return true, nil // 该 Pod 确实经本组件占用了同一监听器 → 真冲突
+		}
+	}
+	return false, nil
 }

--- a/internal/controller/clbbinding.go
+++ b/internal/controller/clbbinding.go
@@ -726,14 +726,26 @@ func (r *CLBBindingReconciler[T]) ensurePortBound(ctx context.Context, bd clbbin
 	if len(targetToDelete) > 0 {
 		for _, target := range targetToDelete {
 			ip := target.TargetIP
-			backend, err := bd.GetAssociatedObjectByIP(ctx, r.Client, ip)
+			other, err := bd.GetAssociatedObjectByIP(ctx, r.Client, ip)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			if backend != nil {
-				msg := fmt.Sprintf("port conflict due to %s:%d/%s is already bound to %s", binding.LoadbalancerId, binding.LoadbalancerPort, binding.Protocol, backend.GetName())
-				r.Recorder.Event(bd.GetObject(), corev1.EventTypeWarning, "OtherTargetBound", msg)
-				return nil
+			if other != nil {
+				// IP 被另一个对象持有，判断是否通过其自己的 CLBBinding 合法占用了同一监听器
+				owned, err := bd.IsListenerOwnedByBackend(ctx, r.Client, other, binding.ListenerId)
+				if err != nil {
+					return errors.WithStack(err)
+				}
+				if owned {
+					// 真冲突：该 IP 被另一对象合法绑在同一监听器，保护，不动
+					msg := fmt.Sprintf("port conflict due to %s:%d/%s is already bound to %s", binding.LoadbalancerId, binding.LoadbalancerPort, binding.Protocol, other.GetName())
+					r.Recorder.Event(bd.GetObject(), corev1.EventTypeWarning, "OtherTargetBound", msg)
+					return nil
+				}
+				// 非合法占用（IP 被无关对象复用）：记一条事件，放行清理
+				r.Recorder.Eventf(bd.GetObject(), corev1.EventTypeNormal, "ReclaimStaleTarget",
+					"stale target %s is reused by %s but not bound to this listener, will deregister",
+					target.TargetIP, other.GetName())
 			}
 		}
 		r.Recorder.Eventf(bd.GetObject(), corev1.EventTypeNormal, "DeregisterTarget", "remove unexpected target: %v", targetToDelete)


### PR DESCRIPTION
## Problem

In VPC-CNI non-static-IP scenarios, when a Pod's IP changes after initial CLB binding and the old IP is reused by another Pod (e.g. a logging agent), the controller gets stuck:

1. Pod A gets IP X, controller binds X to CLB listener
2. Pod A IP changes to Y (e.g. sandbox rebuild due to mount failure)
3. Old IP X is released and reused by unrelated Pod B (no CLB binding)
4. Controller tries to update CLB backend from X to Y, but finds X now belongs to Pod B
5. `OtherTargetBound` protection logic **aborts entirely** — neither deletes stale RS nor registers new IP
6. CLB port permanently points to wrong Pod, traffic unreachable, no self-healing

## Root Cause

`ensurePortBound` in `internal/controller/clbbinding.go` treats ANY Pod holding the stale IP as a conflict, even if that Pod has no CLBBinding to the same listener. The check `GetAssociatedObjectByIP` only answers "who holds this IP now", not "does this object legitimately own this listener via its own CLBBinding".

## Fix

Narrow the conflict detection: only protect when the object holding the stale IP **has its own CLBBinding that legitimately occupies the same listenerId** (true conflict, e.g. shared CLB). Otherwise (IP merely reused by an unrelated object), treat it as stale residue — safe to deregister and replace with the current Pod's real IP.

### Changes

- Add `IsListenerOwnedByBackend` method to the `CLBBinding` interface
- Implement for both `CLBPodBinding` and `CLBNodeBinding` — each checks whether the object holding the stale IP has a CLBBinding whose `Status.PortBindings` includes the same `listenerId`
- Modify `ensurePortBound`: when stale RS IP is held by another object, call `IsListenerOwnedByBackend` before deciding to protect or clean

### Behavior

- **IP reused by unrelated Pod (no CLBBinding)**: `IsListenerOwnedByBackend` returns false → deregister stale RS, register correct IP → self-healing
- **True conflict (another binding owns same listener)**: `IsListenerOwnedByBackend` returns true → `OtherTargetBound` event, skip (same as before)
- **Stale IP not held by any Pod**: `GetAssociatedObjectByIP` returns nil → deregister (same as before)