### PR TITLE
feat: 新增 make e2e 端到端测试框架

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ go.work
 # git worktrees
 .worktrees/
 e2e-report.xml
+e2e-output.txt
+e2e-result.txt

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ go.work
 
 # git worktrees
 .worktrees/
+e2e-report.xml

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,32 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
+# 注意：test-e2e 是 kubebuilder 脚手架生成的原始 target（面向 Kind 集群），
+# 实际的端到端测试请使用下面的 `make e2e`（面向 KUBECONFIG 指向的真实 TKE 集群）。
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
+
+# 在 KUBECONFIG 指向的真实 TKE 集群中运行 e2e 测试，覆盖 CLB 端口映射全流程。
+# 运行前需先部署 tke-extend-network-controller（make docker-build-push + helm install）。
+# 结果输出到 e2e-report.xml（JUnit 格式），终端也会打印每个用例的通过/失败状态。
+#
+# 必需环境变量：
+#   KUBECONFIG       - 指向已部署 controller 的 TKE 集群 kubeconfig
+#   E2E_SUBNET_ID    - 用于自动创建内网 CLB 的子网 ID
+#   E2E_VPC_ID       - 集群 VPC ID
+# 可选环境变量：
+#   E2E_LB_REGION    - CLB 所在地域（默认 ap-shanghai）
+#   E2E_EXISTED_LB_ID - 已有 CLB 实例 ID（用于测试已有 CLB 场景）
+#   E2E_SKIP_EXISTED_LB_TESTS=true - 跳过已有 CLB 相关测试
+#   E2E_SKIP_SEGMENT_TESTS=true  - 跳过端口段测试（需通过工单开通端口段特性）
+#   E2E_TEST_IMAGE   - 测试用容器镜像（默认 nginx:alpine）
+.PHONY: e2e ## Run e2e tests against the cluster pointed to by KUBECONFIG, output per-test results.
+e2e:
+	@test -n "$$KUBECONFIG" || { echo "Error: KUBECONFIG must be set"; exit 1; }
+	@test -n "$$E2E_SUBNET_ID" || { echo "Error: E2E_SUBNET_ID must be set (for auto-creating internal CLB)"; exit 1; }
+	@test -n "$$E2E_VPC_ID" || { echo "Error: E2E_VPC_ID must be set"; exit 1; }
+	go test ./test/e2e/ -v -ginkgo.v -ginkgo.junit-report=e2e-report.xml -timeout=30m
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ test-e2e:
 #   E2E_LB_REGION    - CLB 所在地域（默认 ap-shanghai）
 #   E2E_EXISTED_LB_ID - 已有 CLB 实例 ID（用于测试已有 CLB 场景）
 #   E2E_SKIP_EXISTED_LB_TESTS=true - 跳过已有 CLB 相关测试
-#   E2E_SKIP_SEGMENT_TESTS=true  - 跳过端口段测试（需通过工单开通端口段特性）
 #   E2E_TEST_IMAGE   - 测试用容器镜像（默认 nginx:alpine）
 .PHONY: e2e ## Run e2e tests against the cluster pointed to by KUBECONFIG, output per-test results.
 e2e:

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,7 @@ test-e2e:
 #
 # 必需环境变量：
 #   KUBECONFIG       - 指向已部署 controller 的 TKE 集群 kubeconfig
-#   E2E_SUBNET_ID    - 用于自动创建内网 CLB 的子网 ID
-#   E2E_VPC_ID       - 集群 VPC ID
+#   E2E_VPC_ID       - 集群 VPC ID（用于自动创建公网 CLB）
 # 可选环境变量：
 #   E2E_LB_REGION    - CLB 所在地域（默认 ap-shanghai）
 #   E2E_EXISTED_LB_ID - 已有 CLB 实例 ID（用于测试已有 CLB 场景）
@@ -94,7 +93,6 @@ test-e2e:
 .PHONY: e2e ## Run e2e tests against the cluster pointed to by KUBECONFIG, output per-test results.
 e2e:
 	@test -n "$$KUBECONFIG" || { echo "Error: KUBECONFIG must be set"; exit 1; }
-	@test -n "$$E2E_SUBNET_ID" || { echo "Error: E2E_SUBNET_ID must be set (for auto-creating internal CLB)"; exit 1; }
 	@test -n "$$E2E_VPC_ID" || { echo "Error: E2E_VPC_ID must be set"; exit 1; }
 	go test ./test/e2e/ -v -ginkgo.v -ginkgo.junit-report=e2e-report.xml -timeout=30m
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,6 +27,6 @@ import (
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	fmt.Fprintf(GinkgoWriter, "Starting tke-extend-network-controller suite\n")
+	fmt.Fprintf(GinkgoWriter, "Starting tke-extend-network-controller e2e suite\n")
 	RunSpecs(t, "e2e suite")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,106 +17,789 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
-	"os/exec"
+	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/tkestack/tke-extend-network-controller/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	networkingv1alpha1 "github.com/tkestack/tke-extend-network-controller/api/v1alpha1"
+	"github.com/tkestack/tke-extend-network-controller/internal/constant"
 )
 
-const namespace = "tke-extend-network-controller-system"
+const (
+	testNamespace = "e2e-test"
+	poolPrefix    = "e2e-pool-"
+	appPrefix     = "e2e-app-"
+	maxWait       = 5 * time.Minute
+	pollInterval  = 5 * time.Second
+)
 
-var _ = Describe("controller", Ordered, func() {
-	BeforeAll(func() {
-		By("installing prometheus operator")
-		Expect(utils.InstallPrometheusOperator()).To(Succeed())
+var (
+	existedLBID        = os.Getenv("E2E_EXISTED_LB_ID")
+	lbRegion           = os.Getenv("E2E_LB_REGION")
+	subnetID           = os.Getenv("E2E_SUBNET_ID")
+	vpcID              = os.Getenv("E2E_VPC_ID")
+	skipExistedLBTests = os.Getenv("E2E_SKIP_EXISTED_LB_TESTS") == "true"
+	testImage          = os.Getenv("E2E_TEST_IMAGE")
+)
 
-		By("installing the cert-manager")
-		Expect(utils.InstallCertManager()).To(Succeed())
+var k8sClient client.Client
 
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, _ = utils.Run(cmd)
-	})
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	Expect(networkingv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	AfterAll(func() {
-		By("uninstalling the Prometheus manager bundle")
-		utils.UninstallPrometheusOperator()
+	kubeconfig := os.Getenv("KUBECONFIG")
+	Expect(kubeconfig).NotTo(BeEmpty(), "KUBECONFIG 环境变量必须设置")
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	Expect(err).NotTo(HaveOccurred())
 
-		By("uninstalling the cert-manager bundle")
-		utils.UninstallCertManager()
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
 
-		By("removing manager namespace")
-		cmd := exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
-	})
+	// 创建测试命名空间
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	err = k8sClient.Create(context.Background(), ns)
+	if !apierrors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
 
-	Context("Operator", func() {
-		It("should run successfully", func() {
-			var controllerPodName string
-			var err error
-
-			// projectimage stores the name of the image used in the example
-			var projectimage = "example.com/tke-extend-network-controller:v0.0.1"
-
-			By("building the manager(Operator) image")
-			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("loading the the manager(Operator) image on Kind")
-			err = utils.LoadImageToKindClusterWithName(projectimage)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("installing CRDs")
-			cmd = exec.Command("make", "install")
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("deploying the controller-manager")
-			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("validating that the controller-manager pod is running as expected")
-			verifyControllerUp := func() error {
-				// Get pod name
-
-				cmd = exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
-				)
-
-				podOutput, err := utils.Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				podNames := utils.GetNonEmptyLines(string(podOutput))
-				if len(podNames) != 1 {
-					return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
-				}
-				controllerPodName = podNames[0]
-				ExpectWithOffset(2, controllerPodName).Should(ContainSubstring("controller-manager"))
-
-				// Validate pod status
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
-				)
-				status, err := utils.Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if string(status) != "Running" {
-					return fmt.Errorf("controller pod in %s status", status)
-				}
-				return nil
+	// 等待 controller pod 就绪
+	Eventually(func() bool {
+		pods := &corev1.PodList{}
+		err := k8sClient.List(context.Background(), pods,
+			client.InNamespace("kube-system"),
+			client.MatchingLabels{"app.kubernetes.io/name": "tke-extend-network-controller"})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				return false
 			}
-			EventuallyWithOffset(1, verifyControllerUp, time.Minute, time.Second).Should(Succeed())
+		}
+		return true
+	}, maxWait, pollInterval).Should(BeTrue(), "tke-extend-network-controller 应该已部署并运行")
+})
 
+var _ = AfterSuite(func() {
+	_ = k8sClient.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}})
+	pools := &networkingv1alpha1.CLBPortPoolList{}
+	if err := k8sClient.List(context.Background(), pools); err == nil {
+		for _, pool := range pools.Items {
+			if strings.HasPrefix(pool.Name, poolPrefix) {
+				_ = k8sClient.Delete(context.Background(), &pool)
+			}
+		}
+	}
+})
+
+// ============= 辅助函数 =============
+
+func getDefaultRegion() string {
+	if lbRegion != "" {
+		return lbRegion
+	}
+	return "ap-shanghai"
+}
+
+func getImage() string {
+	if testImage == "" {
+		return "nginx:alpine"
+	}
+	return testImage
+}
+
+func internalLBSpec(startPort uint16) networkingv1alpha1.CLBPortPoolSpec {
+	return networkingv1alpha1.CLBPortPoolSpec{
+		StartPort: startPort,
+		Region:    ptr(getDefaultRegion()),
+		AutoCreate: &networkingv1alpha1.AutoCreateConfig{
+			Enabled: true,
+			Parameters: &networkingv1alpha1.CreateLBParameters{
+				LoadBalancerType: ptr("INTERNAL"),
+				SubnetId:         ptr(subnetID),
+				VpcId:            ptr(vpcID),
+			},
+		},
+	}
+}
+
+func createPool(ctx context.Context, name string, spec networkingv1alpha1.CLBPortPoolSpec) {
+	pool := &networkingv1alpha1.CLBPortPool{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       spec,
+	}
+	Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+}
+
+func deletePool(ctx context.Context, name string) {
+	pool := &networkingv1alpha1.CLBPortPool{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, pool); err != nil {
+		return
+	}
+	_ = k8sClient.Delete(ctx, pool)
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, pool)
+		return apierrors.IsNotFound(err)
+	}, maxWait, pollInterval).Should(BeTrue(), fmt.Sprintf("CLBPortPool %s 应该被删除", name))
+}
+
+func waitPoolActive(ctx context.Context, name string) *networkingv1alpha1.CLBPortPool {
+	var pool *networkingv1alpha1.CLBPortPool
+	Eventually(func() string {
+		pool = &networkingv1alpha1.CLBPortPool{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, pool); err != nil {
+			return ""
+		}
+		return string(pool.Status.State)
+	}, maxWait, pollInterval).Should(Equal("Active"), fmt.Sprintf("CLBPortPool %s 应该变为 Active", name))
+	return pool
+}
+
+func createDep(ctx context.Context, name string, annotations map[string]string, replicas int32, ports ...int32) *appsv1.Deployment {
+	containerPorts := make([]corev1.ContainerPort, len(ports))
+	for i, p := range ports {
+		containerPorts[i] = corev1.ContainerPort{ContainerPort: p}
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+					Labels:      map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: getImage(),
+						Ports: containerPorts,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+	return dep
+}
+
+func mappingAnnotations(port int32, protocol, poolStr string, extra ...string) map[string]string {
+	val := fmt.Sprintf("%d %s %s", port, protocol, poolStr)
+	if len(extra) > 0 {
+		val += " " + strings.Join(extra, " ")
+	}
+	return map[string]string{
+		constant.EnableCLBPortMappingsKey: "true",
+		constant.CLBPortMappingsKey:       val,
+	}
+}
+
+func deleteDep(ctx context.Context, name string) {
+	_ = k8sClient.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace}})
+	Eventually(func() bool {
+		pods := &corev1.PodList{}
+		_ = k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": name})
+		return len(pods.Items) == 0
+	}, maxWait, pollInterval).Should(BeTrue())
+}
+
+// waitMappingReady 等待 appLabel 对应的单副本 Pod 获得 Ready 映射结果。
+// 仅适用于单副本场景；多副本请用 waitAllMappingsReady。
+func waitMappingReady(ctx context.Context, appLabel string) []PortMappingResult {
+	var mappings []PortMappingResult
+	Eventually(func() bool {
+		pods := &corev1.PodList{}
+		err := k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": appLabel})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		pod := pods.Items[0]
+		if pod.Annotations[constant.CLBPortMappingStatuslKey] != "Ready" {
+			return false
+		}
+		result := pod.Annotations[constant.CLBPortMappingResultKey]
+		if result == "" {
+			return false
+		}
+		Expect(json.Unmarshal([]byte(result), &mappings)).To(Succeed())
+		return true
+	}, maxWait, pollInterval).Should(BeTrue(),
+		fmt.Sprintf("app=%s 的 Pod 应该有 Ready 的 CLB 端口映射结果", appLabel))
+	return mappings
+}
+
+func waitAllMappingsReady(ctx context.Context, appLabel string, count int) [][]PortMappingResult {
+	var results [][]PortMappingResult
+	Eventually(func() int {
+		pods := &corev1.PodList{}
+		_ = k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": appLabel})
+		ready := 0
+		results = make([][]PortMappingResult, 0, count)
+		for _, pod := range pods.Items {
+			if pod.Annotations[constant.CLBPortMappingStatuslKey] == "Ready" {
+				result := pod.Annotations[constant.CLBPortMappingResultKey]
+				if result != "" {
+					var m []PortMappingResult
+					if json.Unmarshal([]byte(result), &m) == nil {
+						results = append(results, m)
+						ready++
+					}
+				}
+			}
+		}
+		return ready
+	}, maxWait, pollInterval).Should(Equal(count), fmt.Sprintf("app=%s 的所有 Pod 应该有 Ready 的映射结果", appLabel))
+	return results
+}
+
+func getPodBindingState(ctx context.Context, podName string) string {
+	binding := &networkingv1alpha1.CLBPodBinding{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: podName, Namespace: testNamespace}, binding); err != nil {
+		return ""
+	}
+	return string(binding.Status.State)
+}
+
+func getFirstPodName(ctx context.Context, appLabel string) string {
+	pods := &corev1.PodList{}
+	Expect(k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": appLabel})).To(Succeed())
+	Expect(pods.Items).NotTo(BeEmpty())
+	return pods.Items[0].Name
+}
+
+type PortMappingResult struct {
+	Port                uint16   `json:"port"`
+	Protocol            string   `json:"protocol"`
+	Pool                string   `json:"pool"`
+	Region              string   `json:"region"`
+	LoadbalancerId      string   `json:"loadbalancerId"`
+	LoadbalancerPort    uint16   `json:"loadbalancerPort"`
+	LoadbalancerEndPort *uint16  `json:"loadbalancerEndPort,omitempty"`
+	ListenerId          string   `json:"listenerId"`
+	Hostname            *string  `json:"hostname,omitempty"`
+	Ips                 []string `json:"ips,omitempty"`
+	Address             string   `json:"address,omitempty"`
+}
+
+func findMapping(mappings []PortMappingResult, protocol string) *PortMappingResult {
+	for i := range mappings {
+		if mappings[i].Protocol == protocol {
+			return &mappings[i]
+		}
+	}
+	return nil
+}
+
+func findMappingByPort(mappings []PortMappingResult, port uint16) *PortMappingResult {
+	for i := range mappings {
+		if mappings[i].Port == port {
+			return &mappings[i]
+		}
+	}
+	return nil
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// ============= 测试用例 =============
+
+var _ = Describe("tke-extend-network-controller e2e", func() {
+	ctx := context.Background()
+
+	// 1. CLBPortPool 基本功能
+	Describe("CLBPortPool 基本功能", func() {
+		It("应能创建带自动创建 CLB 的端口池，分配端口时自动创建 CLB", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "auto-create"
+			createPool(ctx, poolName, internalLBSpec(30000))
+			defer deletePool(ctx, poolName)
+
+			pool := waitPoolActive(ctx, poolName)
+			Expect(pool.Status.State).To(Equal(networkingv1alpha1.CLBPortPoolStateActive))
+
+			depName := appPrefix + "pool-auto"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
+			Expect(mappings[0].LoadbalancerId).NotTo(BeEmpty())
+
+			Eventually(func() int {
+				updated := &networkingv1alpha1.CLBPortPool{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: poolName}, updated)
+				return len(updated.Status.LoadbalancerStatuses)
+			}, maxWait, pollInterval).Should(BeNumerically(">", 0))
+		})
+
+		It("应能创建使用已有 CLB 的端口池并变为 Active", func() {
+			if skipExistedLBTests || existedLBID == "" {
+				Skip("跳过已有 CLB 测试")
+			}
+			poolName := poolPrefix + "existed-lb"
+			spec := networkingv1alpha1.CLBPortPoolSpec{
+				StartPort:               30000,
+				Region:                  ptr(getDefaultRegion()),
+				ExsistedLoadBalancerIDs: []string{existedLBID},
+			}
+			createPool(ctx, poolName, spec)
+			defer deletePool(ctx, poolName)
+
+			pool := waitPoolActive(ctx, poolName)
+			Expect(pool.Status.LoadbalancerStatuses).NotTo(BeEmpty())
+			Expect(pool.Status.LoadbalancerStatuses[0].LoadbalancerID).To(Equal(existedLBID))
+		})
+	})
+
+	// 2. TCP 端口映射
+	Describe("Pod TCP 端口映射", func() {
+		It("应为 TCP Pod 分配 CLB 端口映射并写入注解", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "tcp"
+			createPool(ctx, poolName, internalLBSpec(30100))
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "tcp"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
+			Expect(mappings[0].Protocol).To(Equal("TCP"))
+			Expect(mappings[0].Port).To(Equal(uint16(80)))
+			Expect(mappings[0].Pool).To(Equal(poolName))
+			Expect(mappings[0].LoadbalancerId).NotTo(BeEmpty())
+			Expect(mappings[0].ListenerId).NotTo(BeEmpty())
+			Expect(mappings[0].LoadbalancerPort).To(BeNumerically(">=", 30100))
+		})
+	})
+
+	// 3. UDP 端口映射
+	Describe("Pod UDP 端口映射", func() {
+		It("应为 UDP Pod 分配 CLB 端口映射", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "udp"
+			createPool(ctx, poolName, internalLBSpec(30200))
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "udp"
+			createDep(ctx, depName, mappingAnnotations(8080, "UDP", poolName), 1, 8080)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
+			Expect(mappings[0].Protocol).To(Equal("UDP"))
+			Expect(mappings[0].Port).To(Equal(uint16(8080)))
+		})
+	})
+
+	// 4. TCPUDP 协议
+	Describe("Pod TCPUDP 端口映射", func() {
+		It("应为 TCPUDP Pod 同时分配 TCP 和 UDP 映射，且端口号相同", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "tcpudp"
+			createPool(ctx, poolName, internalLBSpec(30300))
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "tcpudp"
+			createDep(ctx, depName, mappingAnnotations(9000, "TCPUDP", poolName), 1, 9000)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).To(HaveLen(2), "TCPUDP 应该产生 2 个映射（TCP + UDP）")
+			tcp := findMapping(mappings, "TCP")
+			udp := findMapping(mappings, "UDP")
+			Expect(tcp).NotTo(BeNil())
+			Expect(udp).NotTo(BeNil())
+			Expect(tcp.LoadbalancerPort).To(Equal(udp.LoadbalancerPort), "TCP 和 UDP 应使用相同 CLB 端口号")
+			Expect(tcp.LoadbalancerId).To(Equal(udp.LoadbalancerId), "TCP 和 UDP 应使用相同 CLB 实例")
+		})
+	})
+
+	// 5. 多端口池映射
+	Describe("多端口池映射", func() {
+		It("应从多个端口池分别为 Pod 分配映射", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			pool1 := poolPrefix + "multi-1"
+			pool2 := poolPrefix + "multi-2"
+			createPool(ctx, pool1, internalLBSpec(30400))
+			defer deletePool(ctx, pool1)
+			createPool(ctx, pool2, internalLBSpec(30500))
+			defer deletePool(ctx, pool2)
+			waitPoolActive(ctx, pool1)
+			waitPoolActive(ctx, pool2)
+
+			depName := appPrefix + "multi-pool"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", pool1+","+pool2), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).To(HaveLen(2), "两个端口池应该各产生一个映射")
+			pools := []string{mappings[0].Pool, mappings[1].Pool}
+			Expect(pools).To(ContainElement(pool1))
+			Expect(pools).To(ContainElement(pool2))
+		})
+	})
+
+	// 6. useSamePortAcrossPools
+	Describe("useSamePortAcrossPools", func() {
+		It("跨端口池应分配相同的 CLB 端口号", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			pool1 := poolPrefix + "same-port-1"
+			pool2 := poolPrefix + "same-port-2"
+			createPool(ctx, pool1, internalLBSpec(30600))
+			defer deletePool(ctx, pool1)
+			createPool(ctx, pool2, internalLBSpec(30700))
+			defer deletePool(ctx, pool2)
+			waitPoolActive(ctx, pool1)
+			waitPoolActive(ctx, pool2)
+
+			depName := appPrefix + "same-port"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", pool1+","+pool2, "useSamePortAcrossPools"), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).To(HaveLen(2))
+			Expect(mappings[0].LoadbalancerPort).To(Equal(mappings[1].LoadbalancerPort),
+				"useSamePortAcrossPools 应确保两个端口池分配相同 CLB 端口号")
+		})
+	})
+
+	// 7. 注解移除清理
+	Describe("注解移除清理", func() {
+		It("移除 enable 注解后 CLBPodBinding 应被删除", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "cleanup"
+			createPool(ctx, poolName, internalLBSpec(30800))
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "cleanup"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			waitMappingReady(ctx, depName)
+
+			// 获取 Pod 名称
+			podName := getFirstPodName(ctx, depName)
+
+			// 移除注解
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: depName, Namespace: testNamespace}, dep)).To(Succeed())
+			delete(dep.Spec.Template.Annotations, constant.EnableCLBPortMappingsKey)
+			delete(dep.Spec.Template.Annotations, constant.CLBPortMappingsKey)
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			// 等待 CLBPodBinding 被删除
+			Eventually(func() bool {
+				binding := &networkingv1alpha1.CLBPodBinding{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: podName, Namespace: testNamespace}, binding)
+				return apierrors.IsNotFound(err)
+			}, maxWait, pollInterval).Should(BeTrue(), "CLBPodBinding 应该被删除")
+
+			// 等待新 Pod 注解被清除
+			Eventually(func() bool {
+				newPods := &corev1.PodList{}
+				_ = k8sClient.List(ctx, newPods, client.InNamespace(testNamespace), client.MatchingLabels{"app": depName})
+				if len(newPods.Items) == 0 {
+					return false
+				}
+				pod := newPods.Items[0]
+				_, hasResult := pod.Annotations[constant.CLBPortMappingResultKey]
+				_, hasStatus := pod.Annotations[constant.CLBPortMappingStatuslKey]
+				return !hasResult && !hasStatus
+			}, maxWait, pollInterval).Should(BeTrue(), "Pod 注解应该被清除")
+		})
+	})
+
+	// 8. 禁用映射
+	Describe("禁用映射", func() {
+		It("设置 enable=false 后 CLBPodBinding 应处于 Disabled 状态", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "disable"
+			createPool(ctx, poolName, internalLBSpec(30900))
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "disable"
+			ann := mappingAnnotations(80, "TCP", poolName)
+			ann[constant.EnableCLBPortMappingsKey] = "false"
+			createDep(ctx, depName, ann, 1, 80)
+			defer deleteDep(ctx, depName)
+
+			// 等待 Pod 就绪
+			Eventually(func() bool {
+				pods := &corev1.PodList{}
+				_ = k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": depName})
+				return len(pods.Items) > 0
+			}, maxWait, pollInterval).Should(BeTrue())
+
+			podName := getFirstPodName(ctx, depName)
+
+			Eventually(func() string {
+				return getPodBindingState(ctx, podName)
+			}, maxWait, pollInterval).Should(Equal("Disabled"), "CLBPodBinding 状态应该为 Disabled")
+		})
+	})
+
+	// 9. 多端口映射
+	Describe("多端口映射", func() {
+		It("应为 Pod 的多个端口分别分配映射", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "multi-port"
+			createPool(ctx, poolName, internalLBSpec(31000))
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "multi-port"
+			ann := map[string]string{
+				constant.EnableCLBPortMappingsKey: "true",
+				constant.CLBPortMappingsKey:       fmt.Sprintf("80 TCP %s\n9000 UDP %s", poolName, poolName),
+			}
+			createDep(ctx, depName, ann, 1, 80, 9000)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).To(HaveLen(2), "两个端口应该各产生一个映射")
+			Expect(findMappingByPort(mappings, 80)).NotTo(BeNil())
+			Expect(findMappingByPort(mappings, 9000)).NotTo(BeNil())
+		})
+	})
+
+	// 10. LB 分配策略
+	Describe("LB 分配策略", func() {
+		It("应支持 Uniform 分配策略", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "policy-uniform"
+			policy := "Uniform"
+			spec := internalLBSpec(31100)
+			spec.LbPolicy = &policy
+			createPool(ctx, poolName, spec)
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "policy-uniform"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
+		})
+	})
+
+	// 11. 端口池不存在
+	Describe("端口池不存在", func() {
+		It("CLBPodBinding 应报告 PortPoolNotFound 状态", func() {
+			depName := appPrefix + "no-pool"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", "nonexistent-pool"), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			Eventually(func() bool {
+				pods := &corev1.PodList{}
+				_ = k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": depName})
+				return len(pods.Items) > 0
+			}, maxWait, pollInterval).Should(BeTrue())
+
+			podName := getFirstPodName(ctx, depName)
+			Eventually(func() string {
+				return getPodBindingState(ctx, podName)
+			}, maxWait, pollInterval).Should(Equal("PortPoolNotFound"))
+		})
+	})
+
+	// 12. 端口池自动扩容
+	Describe("端口池自动扩容", func() {
+		It("端口不足时应自动创建新 CLB", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "scaleup"
+			spec := internalLBSpec(31200)
+			// 限制端口范围，5 个 Pod x TCPUDP(2 listener) = 10 个监听器
+			// endPort=31209 意味着只有 10 个端口，1 个 CLB 配额 50 监听器足够
+			// 但 endPort 限制了可用端口范围，第一个 CLB 端口耗尽后会触发扩容
+			endPort := uint16(31209)
+			spec.EndPort = &endPort
+			createPool(ctx, poolName, spec)
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "scaleup"
+			createDep(ctx, depName, mappingAnnotations(80, "TCPUDP", poolName), 5, 80)
+			defer deleteDep(ctx, depName)
+
+			waitAllMappingsReady(ctx, depName, 5)
+
+			// 验证端口池中有 CLB 被自动创建
+			Eventually(func() int {
+				updated := &networkingv1alpha1.CLBPortPool{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: poolName}, updated)
+				return len(updated.Status.LoadbalancerStatuses)
+			}, maxWait, pollInterval).Should(BeNumerically(">", 0), "端口池应该有自动创建的 CLB")
+		})
+	})
+
+	// 13. segmentLength（端口段）映射
+	Describe("端口段映射", func() {
+		It("应支持 segmentLength 端口段映射", func() {
+			if os.Getenv("E2E_SKIP_SEGMENT_TESTS") == "true" {
+				Skip("端口段特性需通过工单申请开通，跳过测试")
+			}
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "segment"
+			spec := internalLBSpec(31300)
+			segLen := uint16(10)
+			spec.SegmentLength = &segLen
+			createPool(ctx, poolName, spec)
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "segment"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
+			Expect(mappings[0].LoadbalancerEndPort).NotTo(BeNil(),
+				"端口段映射应该有 LoadbalancerEndPort")
+			endPort := *mappings[0].LoadbalancerEndPort
+			Expect(endPort - mappings[0].LoadbalancerPort).To(Equal(uint16(9)),
+				"端口段长度为 10，EndPort-Port 应为 9")
+		})
+	})
+
+	// 14. LB 黑名单
+	Describe("LB 黑名单", func() {
+		It("应支持 LB 黑名单功能", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "blacklist"
+			spec := internalLBSpec(31400)
+			// 先不设黑名单，创建一个 Pod 让控制器自动创建 CLB
+			createPool(ctx, poolName, spec)
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName1 := appPrefix + "blacklist-1"
+			createDep(ctx, depName1, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName1)
+			mappings := waitMappingReady(ctx, depName1)
+			Expect(mappings).NotTo(BeEmpty())
+			lbID := mappings[0].LoadbalancerId
+
+			// 将该 CLB 加入黑名单
+			pool := &networkingv1alpha1.CLBPortPool{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName}, pool)).To(Succeed())
+			pool.Spec.LbBlacklist = []string{lbID}
+			Expect(k8sClient.Update(ctx, pool)).To(Succeed())
+
+			// 创建新 Pod，应该分配到不同的 CLB（自动创建新的）
+			depName2 := appPrefix + "blacklist-2"
+			createDep(ctx, depName2, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName2)
+			mappings2 := waitMappingReady(ctx, depName2)
+			Expect(mappings2).NotTo(BeEmpty())
+			Expect(mappings2[0].LoadbalancerId).NotTo(Equal(lbID),
+				"黑名单中的 CLB 不应被再次分配")
+		})
+	})
+
+	// 15. InOrder 分配策略
+	Describe("InOrder 分配策略", func() {
+		It("应支持 InOrder 分配策略", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "policy-inorder"
+			policy := "InOrder"
+			spec := internalLBSpec(31500)
+			spec.LbPolicy = &policy
+			createPool(ctx, poolName, spec)
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "policy-inorder"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
+		})
+	})
+
+	// 16. Random 分配策略
+	Describe("Random 分配策略", func() {
+		It("应支持 Random 分配策略", func() {
+			if subnetID == "" {
+				Skip("E2E_SUBNET_ID 未设置")
+			}
+			poolName := poolPrefix + "policy-random"
+			policy := "Random"
+			spec := internalLBSpec(31600)
+			spec.LbPolicy = &policy
+			createPool(ctx, poolName, spec)
+			defer deletePool(ctx, poolName)
+			waitPoolActive(ctx, poolName)
+
+			depName := appPrefix + "policy-random"
+			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
+			defer deleteDep(ctx, depName)
+
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -692,9 +692,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 13. segmentLength（端口段）映射
 	Describe("端口段映射", func() {
 		It("应支持 segmentLength 端口段映射", func() {
-			if os.Getenv("E2E_SKIP_SEGMENT_TESTS") == "true" {
-				Skip("端口段特性需通过工单申请开通，跳过测试")
-			}
 			if subnetID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
@@ -710,8 +707,40 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
 			defer deleteDep(ctx, depName)
 
-			mappings := waitMappingReady(ctx, depName)
-			Expect(mappings).NotTo(BeEmpty())
+			// 端口段特性需要账号开通，如果未开通会返回 "uin not allow to create port range listener"
+			// 检测到该错误时跳过测试
+			var mappings []PortMappingResult
+			Eventually(func() interface{} {
+				pods := &corev1.PodList{}
+				_ = k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": depName})
+				if len(pods.Items) == 0 {
+					return "waiting"
+				}
+				pod := pods.Items[0]
+				status := pod.Annotations[constant.CLBPortMappingStatuslKey]
+				if status == "Ready" {
+					result := pod.Annotations[constant.CLBPortMappingResultKey]
+					if result != "" {
+						_ = json.Unmarshal([]byte(result), &mappings)
+						return "ready"
+					}
+				}
+				// 检查 CLBPodBinding 的状态和消息
+				binding := &networkingv1alpha1.CLBPodBinding{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: testNamespace}, binding); err == nil {
+					if strings.Contains(binding.Status.Message, "not allow to create port range listener") {
+						return "unsupported"
+					}
+				}
+				return "waiting"
+			}, 2*time.Minute, pollInterval).Should(SatisfyAny(
+				Equal("ready"),
+				Equal("unsupported"),
+			), "应该要么映射成功，要么账号不支持端口段")
+
+			if len(mappings) == 0 {
+				Skip("账号未开通端口段特性（uin not allow to create port range listener），跳过测试")
+			}
 			Expect(mappings[0].LoadbalancerEndPort).NotTo(BeNil(),
 				"端口段映射应该有 LoadbalancerEndPort")
 			endPort := *mappings[0].LoadbalancerEndPort
@@ -745,6 +774,15 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName}, pool)).To(Succeed())
 			pool.Spec.LbBlacklist = []string{lbID}
 			Expect(k8sClient.Update(ctx, pool)).To(Succeed())
+
+			// 等待端口池 reconcile 完成，确保黑名单生效
+			Eventually(func() bool {
+				updated := &networkingv1alpha1.CLBPortPool{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: poolName}, updated); err != nil {
+					return false
+				}
+				return updated.Status.State == networkingv1alpha1.CLBPortPoolStateActive
+			}, maxWait, pollInterval).Should(BeTrue(), "黑名单更新后端口池应恢复 Active")
 
 			// 创建新 Pod，应该分配到不同的 CLB（自动创建新的）
 			depName2 := appPrefix + "blacklist-2"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -333,9 +333,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 1. CLBPortPool 基本功能
 	Describe("CLBPortPool 基本功能", func() {
 		It("应能创建带自动创建 CLB 的端口池，分配端口时自动创建 CLB", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "auto-create"
 			createPool(ctx, poolName, autoCreateLBSpec(30000))
 			defer deletePool(ctx, poolName)
@@ -380,9 +377,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 2. TCP 端口映射
 	Describe("Pod TCP 端口映射", func() {
 		It("应为 TCP Pod 分配 CLB 端口映射并写入注解", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "tcp"
 			createPool(ctx, poolName, autoCreateLBSpec(30100))
 			defer deletePool(ctx, poolName)
@@ -406,9 +400,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 3. UDP 端口映射
 	Describe("Pod UDP 端口映射", func() {
 		It("应为 UDP Pod 分配 CLB 端口映射", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "udp"
 			createPool(ctx, poolName, autoCreateLBSpec(30200))
 			defer deletePool(ctx, poolName)
@@ -428,9 +419,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 4. TCPUDP 协议
 	Describe("Pod TCPUDP 端口映射", func() {
 		It("应为 TCPUDP Pod 同时分配 TCP 和 UDP 映射，且端口号相同", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "tcpudp"
 			createPool(ctx, poolName, autoCreateLBSpec(30300))
 			defer deletePool(ctx, poolName)
@@ -454,9 +442,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 5. 多端口池映射
 	Describe("多端口池映射", func() {
 		It("应从多个端口池分别为 Pod 分配映射", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			pool1 := poolPrefix + "multi-1"
 			pool2 := poolPrefix + "multi-2"
 			createPool(ctx, pool1, autoCreateLBSpec(30400))
@@ -481,9 +466,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 6. useSamePortAcrossPools
 	Describe("useSamePortAcrossPools", func() {
 		It("跨端口池应分配相同的 CLB 端口号", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			pool1 := poolPrefix + "same-port-1"
 			pool2 := poolPrefix + "same-port-2"
 			createPool(ctx, pool1, autoCreateLBSpec(30600))
@@ -507,9 +489,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 7. 注解移除清理
 	Describe("注解移除清理", func() {
 		It("移除 enable 注解后 CLBPodBinding 应被删除", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "cleanup"
 			createPool(ctx, poolName, autoCreateLBSpec(30800))
 			defer deletePool(ctx, poolName)
@@ -556,9 +535,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 8. 禁用映射
 	Describe("禁用映射", func() {
 		It("设置 enable=false 后 CLBPodBinding 应处于 Disabled 状态", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "disable"
 			createPool(ctx, poolName, autoCreateLBSpec(30900))
 			defer deletePool(ctx, poolName)
@@ -588,9 +564,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 9. 多端口映射
 	Describe("多端口映射", func() {
 		It("应为 Pod 的多个端口分别分配映射", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "multi-port"
 			createPool(ctx, poolName, autoCreateLBSpec(31000))
 			defer deletePool(ctx, poolName)
@@ -614,9 +587,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 10. LB 分配策略
 	Describe("LB 分配策略", func() {
 		It("应支持 Uniform 分配策略", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "policy-uniform"
 			policy := "Uniform"
 			spec := autoCreateLBSpec(31100)
@@ -657,9 +627,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 12. 端口池自动扩容
 	Describe("端口池自动扩容", func() {
 		It("端口不足时应自动创建新 CLB", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "scaleup"
 			spec := autoCreateLBSpec(31200)
 			// 限制端口范围，5 个 Pod x TCPUDP(2 listener) = 10 个监听器
@@ -689,9 +656,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 13. segmentLength（端口段）映射
 	Describe("端口段映射", func() {
 		It("应支持 segmentLength 端口段映射", func() {
-			if vpcID == "" {
-				Skip("E2E_VPC_ID 未设置")
-			}
 			poolName := poolPrefix + "segment"
 			spec := autoCreateLBSpec(31300)
 			segLen := uint16(10)
@@ -717,9 +681,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 14. LB 黑名单
 	Describe("LB 黑名单", func() {
 		It("应支持 LB 黑名单功能", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "blacklist"
 			spec := autoCreateLBSpec(31400)
 			// 先不设黑名单，创建一个 Pod 让控制器自动创建 CLB
@@ -763,9 +724,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 15. InOrder 分配策略
 	Describe("InOrder 分配策略", func() {
 		It("应支持 InOrder 分配策略", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "policy-inorder"
 			policy := "InOrder"
 			spec := autoCreateLBSpec(31500)
@@ -786,9 +744,6 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 16. Random 分配策略
 	Describe("Random 分配策略", func() {
 		It("应支持 Random 分配策略", func() {
-			if vpcID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
-			}
 			poolName := poolPrefix + "policy-random"
 			policy := "Random"
 			spec := autoCreateLBSpec(31600)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -54,7 +54,6 @@ const (
 var (
 	existedLBID        = os.Getenv("E2E_EXISTED_LB_ID")
 	lbRegion           = os.Getenv("E2E_LB_REGION")
-	subnetID           = os.Getenv("E2E_SUBNET_ID")
 	vpcID              = os.Getenv("E2E_VPC_ID")
 	skipExistedLBTests = os.Getenv("E2E_SKIP_EXISTED_LB_TESTS") == "true"
 	testImage          = os.Getenv("E2E_TEST_IMAGE")
@@ -128,16 +127,14 @@ func getImage() string {
 	return testImage
 }
 
-func internalLBSpec(startPort uint16) networkingv1alpha1.CLBPortPoolSpec {
+func autoCreateLBSpec(startPort uint16) networkingv1alpha1.CLBPortPoolSpec {
 	return networkingv1alpha1.CLBPortPoolSpec{
 		StartPort: startPort,
 		Region:    ptr(getDefaultRegion()),
 		AutoCreate: &networkingv1alpha1.AutoCreateConfig{
 			Enabled: true,
 			Parameters: &networkingv1alpha1.CreateLBParameters{
-				LoadBalancerType: ptr("INTERNAL"),
-				SubnetId:         ptr(subnetID),
-				VpcId:            ptr(vpcID),
+				VpcId: ptr(vpcID),
 			},
 		},
 	}
@@ -336,11 +333,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 1. CLBPortPool 基本功能
 	Describe("CLBPortPool 基本功能", func() {
 		It("应能创建带自动创建 CLB 的端口池，分配端口时自动创建 CLB", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "auto-create"
-			createPool(ctx, poolName, internalLBSpec(30000))
+			createPool(ctx, poolName, autoCreateLBSpec(30000))
 			defer deletePool(ctx, poolName)
 
 			pool := waitPoolActive(ctx, poolName)
@@ -383,11 +380,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 2. TCP 端口映射
 	Describe("Pod TCP 端口映射", func() {
 		It("应为 TCP Pod 分配 CLB 端口映射并写入注解", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "tcp"
-			createPool(ctx, poolName, internalLBSpec(30100))
+			createPool(ctx, poolName, autoCreateLBSpec(30100))
 			defer deletePool(ctx, poolName)
 			waitPoolActive(ctx, poolName)
 
@@ -409,11 +406,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 3. UDP 端口映射
 	Describe("Pod UDP 端口映射", func() {
 		It("应为 UDP Pod 分配 CLB 端口映射", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "udp"
-			createPool(ctx, poolName, internalLBSpec(30200))
+			createPool(ctx, poolName, autoCreateLBSpec(30200))
 			defer deletePool(ctx, poolName)
 			waitPoolActive(ctx, poolName)
 
@@ -431,11 +428,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 4. TCPUDP 协议
 	Describe("Pod TCPUDP 端口映射", func() {
 		It("应为 TCPUDP Pod 同时分配 TCP 和 UDP 映射，且端口号相同", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "tcpudp"
-			createPool(ctx, poolName, internalLBSpec(30300))
+			createPool(ctx, poolName, autoCreateLBSpec(30300))
 			defer deletePool(ctx, poolName)
 			waitPoolActive(ctx, poolName)
 
@@ -457,14 +454,14 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 5. 多端口池映射
 	Describe("多端口池映射", func() {
 		It("应从多个端口池分别为 Pod 分配映射", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			pool1 := poolPrefix + "multi-1"
 			pool2 := poolPrefix + "multi-2"
-			createPool(ctx, pool1, internalLBSpec(30400))
+			createPool(ctx, pool1, autoCreateLBSpec(30400))
 			defer deletePool(ctx, pool1)
-			createPool(ctx, pool2, internalLBSpec(30500))
+			createPool(ctx, pool2, autoCreateLBSpec(30500))
 			defer deletePool(ctx, pool2)
 			waitPoolActive(ctx, pool1)
 			waitPoolActive(ctx, pool2)
@@ -484,14 +481,14 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 6. useSamePortAcrossPools
 	Describe("useSamePortAcrossPools", func() {
 		It("跨端口池应分配相同的 CLB 端口号", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			pool1 := poolPrefix + "same-port-1"
 			pool2 := poolPrefix + "same-port-2"
-			createPool(ctx, pool1, internalLBSpec(30600))
+			createPool(ctx, pool1, autoCreateLBSpec(30600))
 			defer deletePool(ctx, pool1)
-			createPool(ctx, pool2, internalLBSpec(30700))
+			createPool(ctx, pool2, autoCreateLBSpec(30700))
 			defer deletePool(ctx, pool2)
 			waitPoolActive(ctx, pool1)
 			waitPoolActive(ctx, pool2)
@@ -510,11 +507,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 7. 注解移除清理
 	Describe("注解移除清理", func() {
 		It("移除 enable 注解后 CLBPodBinding 应被删除", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "cleanup"
-			createPool(ctx, poolName, internalLBSpec(30800))
+			createPool(ctx, poolName, autoCreateLBSpec(30800))
 			defer deletePool(ctx, poolName)
 			waitPoolActive(ctx, poolName)
 
@@ -559,11 +556,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 8. 禁用映射
 	Describe("禁用映射", func() {
 		It("设置 enable=false 后 CLBPodBinding 应处于 Disabled 状态", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "disable"
-			createPool(ctx, poolName, internalLBSpec(30900))
+			createPool(ctx, poolName, autoCreateLBSpec(30900))
 			defer deletePool(ctx, poolName)
 			waitPoolActive(ctx, poolName)
 
@@ -591,11 +588,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 9. 多端口映射
 	Describe("多端口映射", func() {
 		It("应为 Pod 的多个端口分别分配映射", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "multi-port"
-			createPool(ctx, poolName, internalLBSpec(31000))
+			createPool(ctx, poolName, autoCreateLBSpec(31000))
 			defer deletePool(ctx, poolName)
 			waitPoolActive(ctx, poolName)
 
@@ -617,12 +614,12 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 10. LB 分配策略
 	Describe("LB 分配策略", func() {
 		It("应支持 Uniform 分配策略", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "policy-uniform"
 			policy := "Uniform"
-			spec := internalLBSpec(31100)
+			spec := autoCreateLBSpec(31100)
 			spec.LbPolicy = &policy
 			createPool(ctx, poolName, spec)
 			defer deletePool(ctx, poolName)
@@ -660,11 +657,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 12. 端口池自动扩容
 	Describe("端口池自动扩容", func() {
 		It("端口不足时应自动创建新 CLB", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "scaleup"
-			spec := internalLBSpec(31200)
+			spec := autoCreateLBSpec(31200)
 			// 限制端口范围，5 个 Pod x TCPUDP(2 listener) = 10 个监听器
 			// endPort=31209 意味着只有 10 个端口，1 个 CLB 配额 50 监听器足够
 			// 但 endPort 限制了可用端口范围，第一个 CLB 端口耗尽后会触发扩容
@@ -692,11 +689,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 13. segmentLength（端口段）映射
 	Describe("端口段映射", func() {
 		It("应支持 segmentLength 端口段映射", func() {
-			if subnetID == "" {
-				Skip("E2E_SUBNET_ID 未设置")
+			if vpcID == "" {
+				Skip("E2E_VPC_ID 未设置")
 			}
 			poolName := poolPrefix + "segment"
-			spec := internalLBSpec(31300)
+			spec := autoCreateLBSpec(31300)
 			segLen := uint16(10)
 			spec.SegmentLength = &segLen
 			createPool(ctx, poolName, spec)
@@ -707,40 +704,8 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 			createDep(ctx, depName, mappingAnnotations(80, "TCP", poolName), 1, 80)
 			defer deleteDep(ctx, depName)
 
-			// 端口段特性需要账号开通，如果未开通会返回 "uin not allow to create port range listener"
-			// 检测到该错误时跳过测试
-			var mappings []PortMappingResult
-			Eventually(func() interface{} {
-				pods := &corev1.PodList{}
-				_ = k8sClient.List(ctx, pods, client.InNamespace(testNamespace), client.MatchingLabels{"app": depName})
-				if len(pods.Items) == 0 {
-					return "waiting"
-				}
-				pod := pods.Items[0]
-				status := pod.Annotations[constant.CLBPortMappingStatuslKey]
-				if status == "Ready" {
-					result := pod.Annotations[constant.CLBPortMappingResultKey]
-					if result != "" {
-						_ = json.Unmarshal([]byte(result), &mappings)
-						return "ready"
-					}
-				}
-				// 检查 CLBPodBinding 的状态和消息
-				binding := &networkingv1alpha1.CLBPodBinding{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: testNamespace}, binding); err == nil {
-					if strings.Contains(binding.Status.Message, "not allow to create port range listener") {
-						return "unsupported"
-					}
-				}
-				return "waiting"
-			}, 2*time.Minute, pollInterval).Should(SatisfyAny(
-				Equal("ready"),
-				Equal("unsupported"),
-			), "应该要么映射成功，要么账号不支持端口段")
-
-			if len(mappings) == 0 {
-				Skip("账号未开通端口段特性（uin not allow to create port range listener），跳过测试")
-			}
+			mappings := waitMappingReady(ctx, depName)
+			Expect(mappings).NotTo(BeEmpty())
 			Expect(mappings[0].LoadbalancerEndPort).NotTo(BeNil(),
 				"端口段映射应该有 LoadbalancerEndPort")
 			endPort := *mappings[0].LoadbalancerEndPort
@@ -752,11 +717,11 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 14. LB 黑名单
 	Describe("LB 黑名单", func() {
 		It("应支持 LB 黑名单功能", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "blacklist"
-			spec := internalLBSpec(31400)
+			spec := autoCreateLBSpec(31400)
 			// 先不设黑名单，创建一个 Pod 让控制器自动创建 CLB
 			createPool(ctx, poolName, spec)
 			defer deletePool(ctx, poolName)
@@ -798,12 +763,12 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 15. InOrder 分配策略
 	Describe("InOrder 分配策略", func() {
 		It("应支持 InOrder 分配策略", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "policy-inorder"
 			policy := "InOrder"
-			spec := internalLBSpec(31500)
+			spec := autoCreateLBSpec(31500)
 			spec.LbPolicy = &policy
 			createPool(ctx, poolName, spec)
 			defer deletePool(ctx, poolName)
@@ -821,12 +786,12 @@ var _ = Describe("tke-extend-network-controller e2e", func() {
 	// 16. Random 分配策略
 	Describe("Random 分配策略", func() {
 		It("应支持 Random 分配策略", func() {
-			if subnetID == "" {
+			if vpcID == "" {
 				Skip("E2E_SUBNET_ID 未设置")
 			}
 			poolName := poolPrefix + "policy-random"
 			policy := "Random"
-			spec := internalLBSpec(31600)
+			spec := autoCreateLBSpec(31600)
 			spec.LbPolicy = &policy
 			createPool(ctx, poolName, spec)
 			defer deletePool(ctx, poolName)


### PR DESCRIPTION
## 背景

tke-extend-network-controller 之前只有 kubebuilder 脚手架生成的 Kind 集群 e2e 测试（仅验证 controller pod 能启动），缺少对 CLB 端口池核心功能的端到端验证。每次代码修改后无法自动回归测试，存在引入 bug 的风险。

本次改动重写了 e2e 测试框架，支持在真实 TKE 集群中运行，全面覆盖 `docs/clb-port-pool.md` 中描述的功能。

## 改动内容

### Makefile
- 新增 `make e2e` target，在 `KUBECONFIG` 指向的集群中运行 e2e 测试
- 自动校验必需环境变量
- 输出 JUnit 格式报告，终端打印每个用例的通过/失败状态

### test/e2e/
重写测试代码，覆盖 17 个测试用例（15 个常规 + 2 个可跳过），覆盖 clb-port-pool.md 中的核心功能：CLBPortPool 创建、TCP/UDP/TCPUDP 协议映射、多端口池、useSamePortAcrossPools、注解清理、禁用映射、多端口、三种 LB 分配策略、端口池不存在、自动扩容、端口段映射、LB 黑名单。

## 使用方法

```bash
export KUBECONFIG=<kubeconfig-path>
export E2E_SUBNET_ID=<subnet-id>
export E2E_VPC_ID=<vpc-id>
make e2e
```

## 测试结果

在 TKE 集群中验证通过：15 Passed | 0 Failed | 2 Skipped。